### PR TITLE
Experiment to try and make it clearer where the "contract" is defined

### DIFF
--- a/account-service/src/main/resources/bootstrap.yml
+++ b/account-service/src/main/resources/bootstrap.yml
@@ -1,4 +1,3 @@
-# define the name of the application as its registered with eureka
 spring:
   application:
     name: account-service

--- a/account-service/src/main/resources/logback.xml
+++ b/account-service/src/main/resources/logback.xml
@@ -8,8 +8,10 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="DEBUG"/>
+    <logger name="org.xpdojo.bank.cdc.account" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/account-service/src/test/resources/logback-test.xml
+++ b/account-service/src/test/resources/logback-test.xml
@@ -8,8 +8,10 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
+    <logger name="org.xpdojo.bank.cdc.account" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/atm-service/src/main/java/org/xpdojo/bank/cdc/atm/domain/AccountData.java
+++ b/atm-service/src/main/java/org/xpdojo/bank/cdc/atm/domain/AccountData.java
@@ -10,16 +10,16 @@ import java.util.Objects;
 public class AccountData {
 
     private final Long accountNumber;
-    private final String accountDescription;
+    private final String description;
     private final Double overdraftFacility;
     private final Double balance;
 
     public AccountData(@JsonProperty("accountNumber") final Long accountNumber,
-                       @JsonProperty("description") final String accountDescription,
+                       @JsonProperty("description") final String description,
                        @JsonProperty("overdraftFacility") final Amount overdraftFacility,
                        @JsonProperty("balance") final Amount balance) {
         this.accountNumber = accountNumber;
-        this.accountDescription = accountDescription;
+        this.description = description;
         this.overdraftFacility = overdraftFacility.getValue();
         this.balance = balance.getValue();
     }
@@ -28,8 +28,8 @@ public class AccountData {
         return accountNumber;
     }
 
-    public String getAccountDescription() {
-        return accountDescription;
+    public String getDescription() {
+        return description;
     }
 
     public Double getOverdraftFacility() {
@@ -46,21 +46,21 @@ public class AccountData {
         if (o == null || getClass() != o.getClass()) return false;
         AccountData that = (AccountData) o;
         return Objects.equals(accountNumber, that.accountNumber) &&
-                Objects.equals(accountDescription, that.accountDescription) &&
+                Objects.equals(description, that.description) &&
                 Objects.equals(overdraftFacility, that.overdraftFacility) &&
                 Objects.equals(balance, that.balance);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountNumber, accountDescription, overdraftFacility, balance);
+        return Objects.hash(accountNumber, description, overdraftFacility, balance);
     }
 
     @Override
     public String toString() {
         return "AccountData{" +
                 "accountNumber=" + accountNumber +
-                ", accountDescription='" + accountDescription + '\'' +
+                ", description='" + description + '\'' +
                 ", overdraftFacility=" + overdraftFacility +
                 ", balance=" + balance +
                 '}';

--- a/atm-service/src/main/resources/bootstrap.yml
+++ b/atm-service/src/main/resources/bootstrap.yml
@@ -1,4 +1,3 @@
-# define the name of the application as its registered with eureka
 spring:
   application:
     name: atm-service

--- a/atm-service/src/main/resources/logback.xml
+++ b/atm-service/src/main/resources/logback.xml
@@ -8,7 +8,8 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
     <logger name="org.xpdojo.bank.cdc.atm" level="DEBUG"/>
 

--- a/atm-service/src/test/java/org/xpdojo/bank/cdc/atm/pact/AtmConsumerBalancePactTest.java
+++ b/atm-service/src/test/java/org/xpdojo/bank/cdc/atm/pact/AtmConsumerBalancePactTest.java
@@ -69,7 +69,7 @@ public class AtmConsumerBalancePactTest {
 
         AccountData accountData = Jackson2ObjectMapperBuilder.json().build().readValue(response.getBody(), AccountData.class);
         assertThat(accountData.getAccountNumber()).isEqualTo(30002468L);
-        assertThat(accountData.getAccountDescription()).isNotEmpty();
+        assertThat(accountData.getDescription()).isNotEmpty();
         assertThat(accountData.getOverdraftFacility()).isEqualTo(23.0D);
         assertThat(accountData.getBalance()).isEqualTo(1000.0D);
     }

--- a/atm-service/src/test/resources/logback-test.xml
+++ b/atm-service/src/test/resources/logback-test.xml
@@ -8,9 +8,11 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
     <logger name="au.com.dius.pact" level="DEBUG"/>
+    <logger name="org.xpdojo.bank.cdc.atm" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/discovery-service/src/main/resources/bootstrap.yml
+++ b/discovery-service/src/main/resources/bootstrap.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: discovery-service

--- a/discovery-service/src/main/resources/logback.xml
+++ b/discovery-service/src/main/resources/logback.xml
@@ -8,7 +8,8 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
 
     <root level="INFO">

--- a/mobile-banking-service/src/main/resources/bootstrap.yml
+++ b/mobile-banking-service/src/main/resources/bootstrap.yml
@@ -1,4 +1,3 @@
-# define the name of the application as its registered with eureka
 spring:
   application:
     name: mobile-banking-service

--- a/mobile-banking-service/src/main/resources/logback.xml
+++ b/mobile-banking-service/src/main/resources/logback.xml
@@ -8,7 +8,8 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
     <logger name="org.xpdojo.bank.cdc.mobile" level="DEBUG"/>
 

--- a/mobile-banking-service/src/test/java/org/xpdojo/bank/cdc/mobile/pact/Contract.java
+++ b/mobile-banking-service/src/test/java/org/xpdojo/bank/cdc/mobile/pact/Contract.java
@@ -1,0 +1,44 @@
+package org.xpdojo.bank.cdc.mobile.pact;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.model.RequestResponsePact;
+
+import java.util.HashMap;
+import java.util.Map;
+
+interface Contract {
+
+	static RequestResponsePact accountBalanceContract(PactDslWithProvider builder) {
+		return builder
+			.uponReceiving("Request for all accounts")
+			.path("/accounts/30002468/balance")
+			.method("GET")
+			.willRespondWith()
+			.status(200)
+			.headers(expectedHeaders())
+			.body(expectedAccountsBody())
+			.toPact();
+	}
+
+	private static Map<String, String> expectedHeaders() {
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Content-Type", "application/json");
+		return headers;
+	}
+
+	private static PactDslJsonBody expectedAccountsBody() {
+		return new PactDslJsonBody()
+			.id("accountNumber")
+			.stringType("description")
+			.object("overdraftFacility", valueObject())
+			.object("balance", valueObject())
+			.asBody();
+	}
+
+	private static DslPart valueObject() {
+		return new PactDslJsonBody().decimalType("value");
+	}
+
+}

--- a/mobile-banking-service/src/test/java/org/xpdojo/bank/cdc/mobile/pact/MobileConsumerAccountSummaryPactTest.java
+++ b/mobile-banking-service/src/test/java/org/xpdojo/bank/cdc/mobile/pact/MobileConsumerAccountSummaryPactTest.java
@@ -2,8 +2,6 @@ package org.xpdojo.bank.cdc.mobile.pact;
 
 import au.com.dius.pact.consumer.MockServer;
 import au.com.dius.pact.consumer.Pact;
-import au.com.dius.pact.consumer.dsl.DslPart;
-import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
 import au.com.dius.pact.consumer.junit5.PactTestFor;
@@ -18,8 +16,6 @@ import org.springframework.web.client.RestTemplate;
 import org.xpdojo.bank.cdc.mobile.domain.Account;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,59 +23,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 @PactTestFor(providerName = "account_provider")
 public class MobileConsumerAccountSummaryPactTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(MobileConsumerAccountSummaryPactTest.class);
+	private static final Logger LOG = LoggerFactory.getLogger(MobileConsumerAccountSummaryPactTest.class);
 
-    @Pact(provider = "account_provider", consumer = "mobile_consumer")
-    public RequestResponsePact configureMockServer(PactDslWithProvider builder) {
-        return builder
-                .uponReceiving("Request for all accounts")
-                .path("/accounts/30002468/balance")
-                .method("GET")
-                .willRespondWith()
-                .status(200)
-                .headers(expectedHeaders())
-                .body(expectedAccountsBody())
-                .toPact();
-    }
+	@Pact(provider = "account_provider", consumer = "mobile_consumer")
+	public RequestResponsePact getContract(PactDslWithProvider builder) {
+		return Contract.accountBalanceContract(builder);
+	}
 
-    private Map<String, String> expectedHeaders() {
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Content-Type", "application/json");
-        return headers;
-    }
+	@Test
+	void checkWeCanProcessTheAccountData(MockServer mockProvider) throws IOException {
+		ResponseEntity<String> response = retrieveAccountData(mockProvider);
 
-    private PactDslJsonBody expectedAccountsBody() {
-        return new PactDslJsonBody()
-                .id("accountNumber")
-                .stringType("description")
-                .object("overdraftFacility", valueObject())
-                .object("balance", valueObject())
-                .asBody();
-    }
+		assertThat(response.getStatusCode().value()).isEqualTo(200);
+		assertThat(response.getHeaders().get("Content-Type")).contains("application/json");
+		assertThat(response.getBody()).as("Response body from the accounts service is expected to be populated").isNotEmpty();
 
-    private DslPart valueObject() {
-        return new PactDslJsonBody().decimalType("value");
-    }
+		LOG.info(response.getBody());
 
-    @Test
-    void checkWeCanProcessTheAccountData(MockServer mockProvider) throws IOException {
-        ResponseEntity<String> response = retrieveAccountData(mockProvider);
+		Account accountData = Jackson2ObjectMapperBuilder.json().build().readValue(response.getBody(), Account.class);
+		assertThat(accountData.getAccountNumber()).isNotZero();
+		assertThat(accountData.getDescription()).isNotEmpty();
+		assertThat(accountData.getOverdraftFacility()).isNotZero();
+		assertThat(accountData.getBalance()).isNotZero();
+	}
 
-        assertThat(response.getStatusCode().value()).isEqualTo(200);
-        assertThat(response.getHeaders().get("Content-Type")).contains("application/json");
-        assertThat(response.getBody()).as("Response body from the accounts service is expected to be populated").isNotEmpty();
-
-        LOG.info(response.getBody());
-
-        Account accountData = Jackson2ObjectMapperBuilder.json().build().readValue(response.getBody(), Account.class);
-        assertThat(accountData.getAccountNumber()).isNotZero();
-        assertThat(accountData.getDescription()).isNotEmpty();
-        assertThat(accountData.getOverdraftFacility()).isNotZero();
-        assertThat(accountData.getBalance()).isNotZero();
-    }
-
-    private ResponseEntity<String> retrieveAccountData(MockServer mockProvider) {
-        return new RestTemplate().getForEntity(mockProvider.getUrl() + "/accounts/30002468/balance", String.class);
-    }
+	private ResponseEntity<String> retrieveAccountData(MockServer mockProvider) {
+		return new RestTemplate().getForEntity(mockProvider.getUrl() + "/accounts/30002468/balance", String.class);
+	}
 
 }

--- a/mobile-banking-service/src/test/resources/logback-test.xml
+++ b/mobile-banking-service/src/test/resources/logback-test.xml
@@ -8,8 +8,10 @@
     </appender>
 
     <logger name="root" level="INFO"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="com.netflix" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
+    <logger name="org.xpdojo.bank.cdc.mobile" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
I see the test as having two elements 1) the stubbed behaviour that mimics the server (the "contract") and 2) assertions against that.

Experiment to try and formalise that by splitting the former into a `Contract` type. This is really a place to collect factory style methods to setup the stubs. So you might have different methods there to document what you'd expect from different endpoints in different scenarios.

In most of my apps when local / unit testings, we tent to have a bunch a stub creation methods, some parameterised to be configurable.

Something to reflect on (not expecting anyone to merge the PR) and discuss.
